### PR TITLE
Улучшение админ-панели и игнорирование node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+*.log

--- a/db/users.js
+++ b/db/users.js
@@ -1,5 +1,4 @@
-import knex from 'knex';
-import db from '../db/knexfile.js';
+import db from './knexfile.js';
 
 async function createUser(telegramId, username = null, firstName = null, lastName = null, linkChat = null, email = null) {
     try {

--- a/src/controllers/admin/module/usersSettings.js
+++ b/src/controllers/admin/module/usersSettings.js
@@ -1,145 +1,183 @@
 import logger from '../../../utils/logger.js';
-import { searchUsers, getUserDetails, updateUserRole, blockUser, deleteUser, selectAllRoleUsers } from '../../../../db/users.js';
+import {
+    searchUsers,
+    getUserDetails,
+    updateUserRole,
+    blockUser,
+    deleteUser,
+    selectAllRoleUsers
+} from '../../../../db/users.js';
 
 export default function user_settings(scene) {
     scene.action('user_settings', async (ctx) => {
         try {
-            await ctx.deleteMessage();
             await ctx.reply('Введите ID, firstName, lastName или username для поиска пользователей:', {
                 reply_markup: {
-                    inline_keyboard: [[{ text: 'Отмена', callback_data: 'back_to_main' }]]
+                    keyboard: [['Отмена']],
+                    resize_keyboard: true
                 }
             });
-            ctx.session.waitingForUserInput = true;
-            ctx.session.action = `find_user_for_db`;
+            ctx.session.action = 'find_user_for_db';
         } catch (error) {
             logger.error(`Error in user_settings: ${error.message}`, { stack: error.stack });
             await ctx.reply('Произошла ошибка при открытии сцены управления пользователями.');
         }
     });
 
-    scene.action(/^user_(\d+)$/, async (ctx) => {
-        try {
-            if (!ctx.match || !ctx.match[1]) {
-                await ctx.reply('Ошибка: некорректный идентификатор пользователя.');
-                return;
-            }
-
-            const userId = ctx.match[1];
-            const user = await getUserDetails(userId);
-
-            if (!user) {
-                await ctx.reply('Ошибка: пользователь не найден.');
-                return;
-            }
-
-            await ctx.reply(`Информация о пользователе:\n\nID: ${user.id}\nИмя: ${user.firstName} ${user.lastName}\nUsername: ${user.username}\nРоль: ${user.role}\nСтатус: ${user.status}`, {
-                reply_markup: {
-                    inline_keyboard: [
-                        [{ text: 'Обращения', callback_data: `user_requests_${user.id}` }],
-                        [{ text: 'Изменить роль', callback_data: `change_role_${user.id}` }],
-                        [{ text: 'Заблокировать', callback_data: `block_user_${user.id}` }],
-                        [{ text: 'Удалить', callback_data: `delete_user_${user.id}` }],
-                        [{ text: 'Назад', callback_data: 'scene_user_management' }]
-                    ]
-                }
-            });
-        } catch (error) {
-            logger.error(`Error in user selection: ${error.message}`, { stack: error.stack });
-            await ctx.reply('Ошибка при получении данных пользователя.');
-        }
-    });
-
-    scene.action(/^user_requests_(\d+)$/),  async (ctx) => {
-        return await ctx.answerCbQuery('Функция пока в разработке');
-    }
-
-    scene.action(/^change_role_(\d+)$/, async (ctx) => {
-        try {
-            return await ctx.answerCbQuery('Функция пока в разработке');
-            const userId = ctx.match[1];
-            const user = await getUserDetails(userId);
-
-            if (!user) {
-                await ctx.reply('Ошибка: пользователь не найден.');
-                return;
-            }
-
-            const roles = await selectAllRoleUsers();
-
-            const keyboard = [...roles.map(roleItem => [
-                {
-                    text: roleItem.title,
-                    callback_data: `change_role_${roleItem.id}`
-                }
-            ]),
-            [{ text: 'Назад', callback_data: 'back_to_main' }]
-            ];
-
-            await ctx.reply('Введите новую роль для пользователя:', keyboard);
-            ctx.session.action = `update_role_${userId}`;
-        } catch (error) {
-            logger.error(`Error in changing role: ${error.message}`, { stack: error.stack });
-            await ctx.reply('Ошибка при изменении роли пользователя.');
-        }
-    });
-
     scene.on('text', async (ctx) => {
-        if (ctx.session.action && ctx.session.action.startsWith('update_role_')) {
-            try {
-                const userId = ctx.session.action.split('_')[2];
-                const newRole = ctx.message.text.trim();
+        const text = ctx.message.text.trim();
+        const action = ctx.session.action;
 
-                if (!newRole) {
-                    await ctx.reply('Ошибка: введите корректное значение роли.');
+        try {
+            if (action === 'find_user_for_db') {
+                if (text === 'Отмена') {
+                    delete ctx.session.action;
+                    await ctx.reply('Вы вернулись в главное меню администратора.', {
+                        reply_markup: { remove_keyboard: true }
+                    });
+                    await ctx.scene.reenter();
                     return;
                 }
 
-                await updateUserRole(userId, newRole);
-                await ctx.reply(`Роль пользователя успешно изменена на ${newRole}.`);
-                delete ctx.session.action;
-            } catch (error) {
-                logger.error(`Error in updating user role: ${error.message}`, { stack: error.stack });
-                await ctx.reply('Ошибка при обновлении роли.');
+                const users = await searchUsers(text);
+                if (users.length === 0) {
+                    await ctx.reply('Пользователи не найдены. Попробуйте снова.');
+                    return;
+                }
+
+                const keyboard = users.map((user) => [
+                    { text: `${user.id} | ${user.username || user.firstName || ''}` }
+                ]);
+                keyboard.push([{ text: 'Назад' }]);
+
+                await ctx.reply('Выберите пользователя:', {
+                    reply_markup: {
+                        keyboard,
+                        resize_keyboard: true
+                    }
+                });
+                ctx.session.action = 'select_user';
+            } else if (action === 'select_user') {
+                if (text === 'Назад') {
+                    await ctx.reply('Введите ID, firstName, lastName или username для поиска пользователей:', {
+                        reply_markup: {
+                            keyboard: [['Отмена']],
+                            resize_keyboard: true
+                        }
+                    });
+                    ctx.session.action = 'find_user_for_db';
+                    return;
+                }
+
+                const match = text.match(/^(\d+)/);
+                if (!match) {
+                    await ctx.reply('Некорректный выбор пользователя. Попробуйте снова.');
+                    return;
+                }
+
+                const userId = match[1];
+                const user = await getUserDetails(userId);
+                if (!user) {
+                    await ctx.reply('Пользователь не найден.');
+                    return;
+                }
+
+                ctx.session.selectedUserId = userId;
+                ctx.session.action = 'user_menu';
+
+                await ctx.reply(
+                    `Информация о пользователе:\n\nID: ${user.id}\nИмя: ${user.firstName} ${user.lastName}\nUsername: ${user.username}\nРоль: ${user.role}\nСтатус: ${user.status}`,
+                    {
+                        reply_markup: {
+                            keyboard: [
+                                ['Обращения'],
+                                ['Изменить роль'],
+                                ['Заблокировать'],
+                                ['Удалить'],
+                                ['Назад']
+                            ],
+                            resize_keyboard: true
+                        }
+                    }
+                );
+            } else if (action === 'user_menu') {
+                if (text === 'Назад') {
+                    ctx.session.selectedUserId = null;
+                    await ctx.reply('Введите ID, firstName, lastName или username для поиска пользователей:', {
+                        reply_markup: {
+                            keyboard: [['Отмена']],
+                            resize_keyboard: true
+                        }
+                    });
+                    ctx.session.action = 'find_user_for_db';
+                } else if (text === 'Обращения') {
+                    await ctx.reply('Функция пока в разработке.');
+                } else if (text === 'Изменить роль') {
+                    const roles = await selectAllRoleUsers();
+                    const rolesList = roles.map((r) => `${r.id} - ${r.title}`).join('\n');
+                    await ctx.reply(`Доступные роли:\n${rolesList}\n\nВведите ID новой роли:`, {
+                        reply_markup: {
+                            keyboard: [['Отмена']],
+                            resize_keyboard: true
+                        }
+                    });
+                    ctx.session.action = 'update_role';
+                } else if (text === 'Заблокировать') {
+                    const user = await blockUser(ctx.session.selectedUserId);
+                    await ctx.reply(
+                        user.is_blocked ? 'Пользователь заблокирован.' : 'Пользователь разблокирован.'
+                    );
+                } else if (text === 'Удалить') {
+                    const result = await deleteUser(ctx.session.selectedUserId);
+                    await ctx.reply(
+                        result.success ? 'Пользователь удален.' : 'Не удалось удалить пользователя.'
+                    );
+                } else {
+                    await ctx.reply('Неизвестное действие. Выберите опцию из клавиатуры.');
+                }
+            } else if (action === 'update_role') {
+                if (text === 'Отмена') {
+                    await ctx.reply('Действие отменено.', {
+                        reply_markup: {
+                            keyboard: [
+                                ['Обращения'],
+                                ['Изменить роль'],
+                                ['Заблокировать'],
+                                ['Удалить'],
+                                ['Назад']
+                            ],
+                            resize_keyboard: true
+                        }
+                    });
+                    ctx.session.action = 'user_menu';
+                    return;
+                }
+
+                const newRole = Number(text);
+                if (isNaN(newRole)) {
+                    await ctx.reply('Ошибка: введите корректный ID роли.');
+                    return;
+                }
+
+                await updateUserRole(ctx.session.selectedUserId, newRole);
+                await ctx.reply(`Роль пользователя успешно изменена на ${newRole}.`, {
+                    reply_markup: {
+                        keyboard: [
+                            ['Обращения'],
+                            ['Изменить роль'],
+                            ['Заблокировать'],
+                            ['Удалить'],
+                            ['Назад']
+                        ],
+                        resize_keyboard: true
+                    }
+                });
+                ctx.session.action = 'user_menu';
             }
-        }
-    });
-
-    scene.action(/^block_user_(\d+)$/, async (ctx) => {
-        try {
-            return await ctx.answerCbQuery('Функция пока в разработке');
-            const userId = ctx.match[1];
-            const user = await getUserDetails(userId);
-
-            if (!user) {
-                await ctx.reply('Ошибка: пользователь не найден.');
-                return;
-            }
-
-            await blockUser(userId);
-            await ctx.reply('Пользователь заблокирован.');
         } catch (error) {
-            logger.error(`Error in blocking user: ${error.message}`, { stack: error.stack });
-            await ctx.reply('Ошибка при блокировке пользователя.');
-        }
-    });
-
-    scene.action(/^delete_user_(\d+)$/, async (ctx) => {
-        try {
-            return await ctx.answerCbQuery('Функция пока в разработке');
-            const userId = ctx.match[1];
-            const user = await getUserDetails(userId);
-
-            if (!user) {
-                await ctx.reply('Ошибка: пользователь не найден.');
-                return;
-            }
-
-            await deleteUser(userId);
-            await ctx.reply('Пользователь удален.');
-        } catch (error) {
-            logger.error(`Error in deleting user: ${error.message}`, { stack: error.stack });
-            await ctx.reply('Ошибка при удалении пользователя.');
+            logger.error(`Error in user settings: ${error.message}`, { stack: error.stack });
+            await ctx.reply('Произошла ошибка. Попробуйте снова.');
         }
     });
 }
+


### PR DESCRIPTION
## Summary
- ignore node modules, env files and logs
- add role change, block and delete actions in admin user manager
- switch admin user manager to reply keyboard without deleting messages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68aec1ea311c832386be15de2e9c97b7