### PR TITLE
refactor: centralize knex client initialization

### DIFF
--- a/db/client.js
+++ b/db/client.js
@@ -1,0 +1,4 @@
+import knex from 'knex';
+import config from './knexfile.js';
+const db = knex(config);
+export default db;

--- a/db/knexfile.js
+++ b/db/knexfile.js
@@ -1,6 +1,4 @@
-import knex from 'knex';
-
-const db = knex({
+export default {
     client: 'pg',
     connection: {
         host: '192.168.126.128',
@@ -27,9 +25,7 @@ const db = knex({
     },
     useNullAsDefault: true,
     searchPath: ['bot_schema', 'public']
-});
-
-export default db;
+};
 
 //npx knex migrate:latest
 //npx knex seed:make initial_data

--- a/db/migrate.js
+++ b/db/migrate.js
@@ -1,4 +1,4 @@
-import db from'./knexfile.js';
+import db from './client.js';
 
 db.migrate.latest()
     .then(() => {

--- a/db/users.js
+++ b/db/users.js
@@ -1,5 +1,4 @@
-import knex from 'knex';
-import db from '../db/knexfile.js';
+import db from './client.js';
 
 async function createUser(telegramId, username = null, firstName = null, lastName = null, linkChat = null, email = null) {
     try {


### PR DESCRIPTION
## Summary
- export raw configuration from `db/knexfile.js`
- add `db/client.js` to initialize and export the Knex instance
- update database imports to pull from the new client

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68aec737cfc0832393df7a589c853c10