### PR TITLE
feat: email reports from folder

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -13,7 +13,7 @@ import classification from "./controllers/classification/index.js";
 import reportIssue from "./controllers/reportIssue/index.js";
 import admin from "./controllers/admin/index.js";
 import userCheckMiddleware from "./middlewares/checkUser.js";
-import { startTicketEmailSender } from "./utils/emailConfig.js";
+import { startReportEmailSender } from "./utils/emailConfig.js";
 
 
 dotenv.config();
@@ -58,7 +58,7 @@ class Bot {
     this.setupMiddleware();
     this.registerHandlers();
     this.start();
-    this.emailInterval = startTicketEmailSender();
+    this.emailInterval = startReportEmailSender();
   }
 
   setupMiddleware() {

--- a/src/controllers/reportIssue/index.js
+++ b/src/controllers/reportIssue/index.js
@@ -14,12 +14,14 @@ const reportIssue = new Scenes.BaseScene('reportIssue');
 const MAX_FILES = 10;
 // Максимальный размер файла (20 МБ в байтах)
 const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 МБ
+// Максимальный общий объем файлов (24 МБ в байтах)
+const MAX_TOTAL_SIZE = 24 * 1024 * 1024; // 24 МБ
 
 reportIssue.enter(async (ctx) => {
     try {
         await ctx.reply(
             'Пожалуйста, опишите вашу проблему. Вы также можете прикрепить файлы (изображения, видео, кружки, голосовые сообщения, PDF, документы). ' +
-            `Максимум ${MAX_FILES} файлов, размер каждого файла не более 20 МБ.\n\nКогда закончите, отправьте сообщение с текстом "Готово" или нажмите на кнопку ниже.`,
+            `Максимум ${MAX_FILES} файлов, размер каждого файла не более 20 МБ, общий объем не более 24 МБ.\n\nКогда закончите, отправьте сообщение с текстом "Готово" или нажмите на кнопку ниже.`,
             {
                 reply_markup: {
                     keyboard: [['Готово'], ['Назад']],
@@ -30,7 +32,8 @@ reportIssue.enter(async (ctx) => {
         );
         ctx.session.issueData = {
             description: '',
-            files: [] // Теперь будет массив объектов { name, buffer, caption }
+            files: [], // Теперь будет массив объектов { name, buffer, caption }
+            totalSize: 0
         };
         logger.info(`User ${ctx.from.id} entered reportIssue scene`);
     } catch (error) {
@@ -104,7 +107,7 @@ reportIssue.on('text', async (ctx) => {
             const issueData = {
                 user: ctx.from.id.toString(),
                 type: ctx.session.ticketType,
-                company: ctx.session.selectedOrganization,
+                company: ctx.session.selectedOrganization || 'Не указано',
                 filial: ctx.session.selectedBranch,
                 classification: ctx.session.selectedClassification,
                 text: ctx.session.issueData.description,
@@ -214,6 +217,12 @@ reportIssue.on(['photo', 'video', 'video_note', 'voice', 'document'], async (ctx
             return;
         }
 
+        const remainingTotal = MAX_TOTAL_SIZE - ctx.session.issueData.totalSize;
+        if (fileSize > remainingTotal) {
+            await ctx.reply(`Нельзя загрузить файл, превышен общий лимит 24 МБ. Осталось ${(remainingTotal / (1024 * 1024)).toFixed(2)} МБ.`);
+            return;
+        }
+
         const fileLink = await ctx.telegram.getFileLink(file.file_id);
         const response = await fetch(fileLink);
         const buffer = Buffer.from(await response.arrayBuffer());
@@ -224,8 +233,10 @@ reportIssue.on(['photo', 'video', 'video_note', 'voice', 'document'], async (ctx
             buffer: buffer,
             caption: caption
         });
+        ctx.session.issueData.totalSize += fileSize;
 
-        await ctx.reply(`Файл ${fileName} добавлен${caption ? ' с описанием: ' + caption : ''}. Осталось ${MAX_FILES - ctx.session.issueData.files.length} из ${MAX_FILES} файлов.`);
+        const freeSpace = MAX_TOTAL_SIZE - ctx.session.issueData.totalSize;
+        await ctx.reply(`Файл ${fileName} добавлен${caption ? ' с описанием: ' + caption : ''}. Осталось ${MAX_FILES - ctx.session.issueData.files.length} из ${MAX_FILES} файлов. Свободно ${(freeSpace / (1024 * 1024)).toFixed(2)} МБ из 24 МБ.`);
         logger.info(`User ${ctx.from.id} uploaded file ${fileName}${caption ? ' with caption: ' + caption : ''}`);
     } catch (error) {
         logger.error(`Error handling file upload: ${error.message}`);
@@ -257,7 +268,7 @@ async function saveTicketFromFolder(telegramId, ticketFolder) {
       .insert({
         user_id: user.id,
         message: issueData.text,
-        organization: issueData.company,
+        organization: issueData.company || 'Не указано',
         branch: issueData.filial,
         classification: issueData.classification,
         created_at: db.fn.now(),


### PR DESCRIPTION
## Summary
- send unsent reports from `src/reports` to support mailbox using credentials from `config.json`
- schedule periodic report email sender in bot startup

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "import('./src/utils/emailConfig.js').then(m=>m.sendReportsFromFolder())"` *(fails: SyntaxError: Identifier '.default' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_b_68aed0c2d0bc8323b4099aec4ea21bb7