### PR TITLE
Add profile view and email verification support

### DIFF
--- a/db/users.js
+++ b/db/users.js
@@ -22,8 +22,11 @@ async function createUser(telegramId, username = null, firstName = null, lastNam
 async function findUserByTelegramId(telegramId) {
     try {
         return await db('users')
-            .where({ id_telegram: telegramId })
-            .first(); // Работает одинаково в обоих диалектах
+            .leftJoin('tickets', 'users.id', 'tickets.user_id')
+            .select('users.*', 'tickets.organization as organization', 'tickets.branch as branch')
+            .where('users.id_telegram', telegramId)
+            .orderBy('tickets.created_at', 'desc')
+            .first(); // Возвращает пользователя с последними организацией и филиалом
     } catch (error) {
         console.error(`Error finding user by Telegram ID: ${error.message}`);
         throw error;


### PR DESCRIPTION
## Summary
- expose Profile button in welcome scene to show user details and account status
- allow confirming or changing email with resend code limit
- fetch user's organization and branch from latest ticket when loading profile

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68aee79111008323a758b30c797cc856