### PR TITLE
Add profile view, email verification, and config-based admin access

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -115,6 +115,9 @@
       "priority": 2
     }
   },
+  "administrators": [
+    123456789
+  ],
   "general": {
     "email": {
       "host": "smtp.yandex.ru",

--- a/db/users.js
+++ b/db/users.js
@@ -22,8 +22,11 @@ async function createUser(telegramId, username = null, firstName = null, lastNam
 async function findUserByTelegramId(telegramId) {
     try {
         return await db('users')
-            .where({ id_telegram: telegramId })
-            .first(); // Работает одинаково в обоих диалектах
+            .leftJoin('tickets', 'users.id', 'tickets.user_id')
+            .select('users.*', 'tickets.organization as organization', 'tickets.branch as branch')
+            .where('users.id_telegram', telegramId)
+            .orderBy('tickets.created_at', 'desc')
+            .first(); // Возвращает пользователя с последними организацией и филиалом
     } catch (error) {
         console.error(`Error finding user by Telegram ID: ${error.message}`);
         throw error;

--- a/src/bot.js
+++ b/src/bot.js
@@ -14,6 +14,7 @@ import reportIssue from "./controllers/reportIssue/index.js";
 import admin from "./controllers/admin/index.js";
 import userCheckMiddleware from "./middlewares/checkUser.js";
 import { startReportEmailSender } from "./utils/emailConfig.js";
+import ConfigLoader from "./utils/configLoader.js";
 
 
 dotenv.config();
@@ -109,6 +110,12 @@ class Bot {
     // Admin command
     this.bot.command("admin", async (ctx) => {
       try {
+        const config = await ConfigLoader.loadConfig();
+        const admins = config.administrators || [];
+        if (!admins.includes(ctx.from.id)) {
+          await ctx.reply("У вас нет доступа к этому разделу.");
+          return;
+        }
         await ctx.scene.enter("admin");
         logger.info(`User ${ctx.from.id} entered admin scene`);
       } catch (error) {


### PR DESCRIPTION
## Summary
- expose Profile button in welcome scene to show user details and account status
- allow confirming or changing email with resend code limit
- fetch user's organization and branch from latest ticket when loading profile
- read admin Telegram IDs from config.json to gate the management button and /admin command

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68aee79111008323a758b30c797cc856