### PR TITLE
feat: manage users and requests

### DIFF
--- a/db/users.js
+++ b/db/users.js
@@ -194,6 +194,18 @@ async function getTicketsByUserId(userId) {
     }
 }
 
+async function getTicketDetails(ticketId) {
+    try {
+        const ticket = await db('tickets').where({ id: ticketId }).first();
+        if (!ticket) return null;
+        const files = await db('files').where({ ticket_id: ticketId });
+        return { ticket, files };
+    } catch (error) {
+        console.error(`Error getting ticket details: ${error.message}`);
+        throw error;
+    }
+}
+
 async function getStatistics() {
     try {
         const [users] = await db('users').count('id as count');
@@ -225,5 +237,6 @@ export {
     createTicket,
     createFile,
     getTicketsByUserId,
+    getTicketDetails,
     getStatistics
 };


### PR DESCRIPTION
## Summary
- add database utility to retrieve ticket details with attached files
- implement admin actions to view user requests, download archives, block and delete users

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68aef19048e08323b4eaf328fa1059be