### PR TITLE
feat: add spam protection middleware

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -13,6 +13,7 @@ import classification from './controllers/classification/index.js';
 import reportIssue from './controllers/reportIssue/index.js';
 import admin from './controllers/admin/index.js';
 import userCheckMiddleware from './middlewares/checkUser.js';
+import spamProtection from './middlewares/spamProtection.js';
 import { startReportEmailSender } from './utils/emailConfig.js';
 import ConfigLoader from './utils/configLoader.js';
 
@@ -68,7 +69,8 @@ class Bot {
       getSessionKey: (ctx) => ctx.chat?.id?.toString()
     });
 
-    // Подключаем проверки пользователя, сессии и сцены
+    // Подключаем защиты от спама, проверки пользователя, сессию и сцены
+    this.bot.use(spamProtection());
     this.bot.use(userCheckMiddleware);
     this.bot.use(localSession.middleware());
     this.bot.use(stage.middleware());

--- a/src/middlewares/spamProtection.js
+++ b/src/middlewares/spamProtection.js
@@ -1,0 +1,27 @@
+import logger from '../utils/logger.js';
+
+// Simple rate limiting middleware to prevent message spam
+// limit: number of messages
+// interval: time window in milliseconds
+export default function spamProtection({ limit = 5, interval = 10000 } = {}) {
+  const userTimestamps = new Map();
+
+  return async (ctx, next) => {
+    const userId = ctx.from?.id;
+    if (!userId) return next();
+
+    const now = Date.now();
+    const timestamps = userTimestamps.get(userId) || [];
+    const recent = timestamps.filter((t) => now - t < interval);
+    recent.push(now);
+    userTimestamps.set(userId, recent);
+
+    if (recent.length > limit) {
+      logger.warn(`User ${userId} is sending messages too frequently`);
+      await ctx.reply('Пожалуйста, не отправляйте сообщения так часто.');
+      return;
+    }
+
+    await next();
+  };
+}


### PR DESCRIPTION
## Summary
- add middleware to limit messages per user and warn on spam
- integrate spam protection into bot middleware chain

## Testing
- `npm test` *(fails: "Error: no test specified")*


------
https://chatgpt.com/codex/tasks/task_b_68af0a0da9f08323b3d57f860c6e089a