### PR TITLE
Add Docker build and compose configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+Dockerfile
+docker-compose.yml
+.git
+.gitignore
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Use official Node.js LTS image
+FROM node:20-alpine
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Bundle app source
+COPY . .
+
+# Expose necessary port (if any - bot doesn't listen on port but for completeness maybe? but maybe not needed). We'll not expose.
+# Start the bot
+CMD ["node", "src/bot.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+services:
+  bot:
+    build: .
+    command: node src/bot.js
+    env_file: .env
+    volumes:
+      - ./db:/usr/src/app/db
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add Dockerfile to containerize the bot
- define docker-compose service with environment file and persistent database volume
- ignore development artifacts during Docker builds

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68af0c7fb22c8323bbed981bcbb641fb