### PR TITLE
feat: allow adding admins via panel

### DIFF
--- a/db/knexfile.js
+++ b/db/knexfile.js
@@ -1,6 +1,4 @@
-import dotenv from 'dotenv';
-
-dotenv.config();
+import '../env.js';
 
 const config = {
   client: 'pg',

--- a/env.js
+++ b/env.js
@@ -1,0 +1,8 @@
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+dotenv.config({ path: resolve(__dirname, '.env') });

--- a/src/bot.js
+++ b/src/bot.js
@@ -1,4 +1,4 @@
-import dotenv from 'dotenv';
+import '../env.js';
 import { Telegraf, Scenes } from 'telegraf';
 import LocalSession from 'telegraf-session-local';
 import { HttpsProxyAgent } from 'https-proxy-agent';
@@ -16,9 +16,6 @@ import userCheckMiddleware from './middlewares/checkUser.js';
 import spamProtection from './middlewares/spamProtection.js';
 import { startReportEmailSender } from './utils/emailConfig.js';
 import ConfigLoader from './utils/configLoader.js';
-
-// Загружаем переменные окружения
-dotenv.config();
 
 const { BOT_TOKEN, PROXY_URL } = process.env;
 

--- a/src/controllers/admin/index.js
+++ b/src/controllers/admin/index.js
@@ -7,6 +7,7 @@ import orgSettings from './module/orgSettings.js';
 import classificationSettings from './module/classificationSettings.js';
 import emailSettings from './module/emailSettings.js';
 import userSettings from './module/usersSettings.js';
+import adminSettings from './module/adminSettings.js';
 import { searchUsers, getStatistics, getTicketDetails } from "../../../db/users.js";
 import path from 'path';
 
@@ -23,7 +24,8 @@ admin.enter(async (ctx) => {
                     [{ text: '3. Настройка классификаций', callback_data: 'classification_settings' }],
                     [{ text: '4. Настройка email', callback_data: 'email_settings' }],
                     [{ text: '5. Управление пользователями', callback_data: 'user_settings' }],
-                    [{ text: '6. Статистика', callback_data: 'statistics' }],
+                    [{ text: '6. Администраторы', callback_data: 'admin_settings' }],
+                    [{ text: '7. Статистика', callback_data: 'statistics' }],
                     [{ text: 'Выход', callback_data: 'scene_admin_exit' }]
                 ]
             }
@@ -281,6 +283,22 @@ admin.on('text', async (ctx) => {
                         ]
                     }
                 });
+            } else if (action === 'add_admin') {
+                const digits = text.replace(/\D/g, '');
+                if (!digits) {
+                    await ctx.reply('ID должен содержать только цифры.', {
+                        reply_markup: {
+                            inline_keyboard: [[{ text: 'Назад', callback_data: 'admin_settings' }]]
+                        }
+                    });
+                } else {
+                    const added = await ConfigLoader.addAdministrator(digits);
+                    await ctx.reply(added ? `Пользователь ${digits} добавлен в администраторы.` : 'Пользователь уже является администратором.', {
+                        reply_markup: {
+                            inline_keyboard: [[{ text: 'Назад', callback_data: 'admin_settings' }]]
+                        }
+                    });
+                }
             } else if (action === 'find_user_for_db')
             {
                 if (!ctx.session.waitingForUserInput) return;
@@ -382,6 +400,7 @@ try {
     classificationSettings(admin);
     emailSettings(admin);
     userSettings(admin);
+    adminSettings(admin);
 } catch (error) {
     logger.error(`Error initializing admin modules: ${error.message}`, { stack: error.stack });
 }

--- a/src/controllers/admin/module/adminSettings.js
+++ b/src/controllers/admin/module/adminSettings.js
@@ -1,0 +1,42 @@
+import logger from '../../../utils/logger.js';
+import ConfigLoader from '../../../utils/configLoader.js';
+
+export default function adminSettings(scene) {
+  // Display current administrators and options
+  scene.action('admin_settings', async (ctx) => {
+    try {
+      await ctx.deleteMessage();
+      const config = await ConfigLoader.loadConfig();
+      const admins = config.administrators || [];
+      const list = admins.length ? admins.join(', ') : 'Список пуст';
+      await ctx.reply(`Текущие администраторы:\n${list}`, {
+        reply_markup: {
+          inline_keyboard: [
+            [{ text: 'Добавить администратора', callback_data: 'prompt_add_admin' }],
+            [{ text: 'Назад', callback_data: 'back_to_main' }],
+          ],
+        },
+      });
+    } catch (error) {
+      logger.error(`Error in admin_settings action: ${error.message}`, { stack: error.stack });
+      await ctx.reply('Извините, произошла ошибка при отображении администраторов.');
+    }
+  });
+
+  // Prompt for new administrator ID
+  scene.action('prompt_add_admin', async (ctx) => {
+    try {
+      await ctx.deleteMessage();
+      await ctx.reply('Введите Telegram ID пользователя:', {
+        reply_markup: {
+          inline_keyboard: [[{ text: 'Отмена', callback_data: 'admin_settings' }]],
+        },
+      });
+      ctx.session.action = 'add_admin';
+    } catch (error) {
+      logger.error(`Error in prompt_add_admin action: ${error.message}`, { stack: error.stack });
+      await ctx.reply('Извините, произошла ошибка при запросе ID.');
+    }
+  });
+}
+

--- a/src/utils/configLoader.js
+++ b/src/utils/configLoader.js
@@ -271,6 +271,36 @@ class ConfigLoader {
         logger.info(`Hid organization with key ${orgKey}`);
     }
 
+    // === Administrators ===
+    static async addAdministrator(telegramId) {
+        const config = await ConfigLoader.loadConfig();
+        config.administrators = config.administrators || [];
+        const id = Number(telegramId);
+        if (!config.administrators.includes(id)) {
+            config.administrators.push(id);
+            await ConfigLoader.saveConfig(config);
+            logger.info(`Added administrator ${id}`);
+            return true;
+        }
+        logger.warn(`Administrator ${id} already exists`);
+        return false;
+    }
+
+    static async removeAdministrator(telegramId) {
+        const config = await ConfigLoader.loadConfig();
+        config.administrators = config.administrators || [];
+        const id = Number(telegramId);
+        const index = config.administrators.indexOf(id);
+        if (index !== -1) {
+            config.administrators.splice(index, 1);
+            await ConfigLoader.saveConfig(config);
+            logger.info(`Removed administrator ${id}`);
+            return true;
+        }
+        logger.warn(`Administrator ${id} not found`);
+        return false;
+    }
+
     static async updateSceneText(sceneKey, text) {
         const config = await ConfigLoader.loadConfig();
         if (!config.controllers[sceneKey]) {


### PR DESCRIPTION
## Summary
- allow administrator IDs to be added from the admin panel
- store admin list updates in config via new helper
- ensure environment variables load from the project root

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68af133a87e4832388ff0a089d64cd1a