### PR TITLE
Redirect users to welcome scene on errors

### DIFF
--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -1,0 +1,12 @@
+import logger from './logger.js';
+
+export default async function handleError(ctx, error, message = 'An error occurred. Returning to main menu.') {
+  logger.error(`Handler error: ${error.message}`, { stack: error.stack });
+  try {
+    await ctx.scene.enter('welcome');
+  } catch (err) {
+    logger.error(`Failed to enter welcome scene: ${err.message}`, { stack: err.stack });
+  }
+  // eslint-disable-next-line no-void
+  void ctx.reply(message);
+}


### PR DESCRIPTION
## Summary
- add reusable `handleError` utility that logs errors and redirects users to the `welcome` scene
- refactor bot handlers to use the centralized error handler and return users to the main menu on failures

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68af6650e300832386285364c396192c