### PR TITLE
Ensure all Telegram messages use HTML formatting

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -19,6 +19,7 @@ import admin from './controllers/admin/index.js';
 
 import userCheckMiddleware from './middlewares/checkUser.js';
 import spamProtection from './middlewares/spamProtection.js';
+import forceHtml from './middlewares/forceHtml.js';
 
 import { startReportEmailSender } from './utils/emailConfig.js';
 import ConfigLoader from './utils/configLoader.js';
@@ -94,6 +95,9 @@ export class Bot {
   }
 
   setupMiddleware() {
+    // 0) принудительное использование HTML
+    this.bot.use(forceHtml());
+
     // 1) сессии
     this.bot.use(
       session({

--- a/src/middlewares/forceHtml.js
+++ b/src/middlewares/forceHtml.js
@@ -1,0 +1,36 @@
+export default () => async (ctx, next) => {
+  const wrap = (target, method) => {
+    const original = target[method];
+    if (typeof original !== 'function') return;
+    const bound = original.bind(target);
+    // eslint-disable-next-line no-param-reassign
+    target[method] = (...args) => {
+      const callArgs = [...args];
+      const last = callArgs[callArgs.length - 1];
+      if (last && typeof last === 'object' && !Array.isArray(last)) {
+        callArgs[callArgs.length - 1] = { parse_mode: 'HTML', ...last };
+      } else {
+        callArgs.push({ parse_mode: 'HTML' });
+      }
+      return bound(...callArgs);
+    };
+  };
+
+  wrap(ctx, 'reply');
+  wrap(ctx, 'replyWithPhoto');
+  wrap(ctx, 'replyWithDocument');
+  wrap(ctx, 'replyWithVideo');
+  wrap(ctx, 'replyWithAnimation');
+  wrap(ctx, 'editMessageText');
+  wrap(ctx, 'editMessageCaption');
+
+  wrap(ctx.telegram, 'sendMessage');
+  wrap(ctx.telegram, 'editMessageText');
+  wrap(ctx.telegram, 'editMessageCaption');
+  wrap(ctx.telegram, 'sendPhoto');
+  wrap(ctx.telegram, 'sendDocument');
+  wrap(ctx.telegram, 'sendVideo');
+  wrap(ctx.telegram, 'sendAnimation');
+
+  return next();
+};


### PR DESCRIPTION
## Summary
- add a middleware that injects `parse_mode: HTML` into common Telegram send and edit methods
- register the middleware during bot setup so every message defaults to HTML

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68af6a7a8d7083238569929d4911c9b7